### PR TITLE
Gulp tasks cleaning:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 BIN = ./node_modules/.bin
 
+h: help
 help:
 	@cat Makefile.help
 
-# Install the dependancies
 i: install
 install:
 	npm prune
@@ -12,39 +12,23 @@ install:
 r: reset
 reset:
 	rm -Rf node_modules
-	rm -Rf lib
 
-# Clean generated files
 c: clean
 clean:
 	$(BIN)/gulp clean
 
-# Generate and compile everything needed
 b: build
 build:
 	$(BIN)/gulp build
 
-# Lauch watcher on dev sources and run required compilators
-w: watch
-watch:
-	$(BIN)/gulp watch
+web:
+	$(BIN)/gulp web:dev
 
-wapi: watchapi
-watchapi:
-	$(BIN)/gulp watch:api
-
-n: new
-new: clean reset install build
-
-cb: clean build
-bw: build watch
-cbw: clean build watch
-
-d: doc
-doc:
-	./node_modules/.bin/jsdoc --readme README.md -c .jsdoc
+api:
+	$(BIN)/gulp api:dev
 
 module:
-	$(BIN)/gulp module
-api:
-	$(BIN)/gulp module:api
+	$(BIN)/gulp create-module
+
+unused:
+	$(BIN)/gulp unusedPackages

--- a/Makefile.help
+++ b/Makefile.help
@@ -7,15 +7,12 @@
  (   9   )
 (_\_____/_)`
 
+[h]elp    : that help text
 [i]nstall : install all packages dependancies
 [r]eset   : remove all the packages files
-[c]lean   : remove all the generated files
 [b]uild   : generate all the files
-[w]atch   : start the server and watch changing files
-[n]ew     : reinstall and regenerate all files
-
-[cb]      : run clean, then build
-[bw]      : run build, then watch
-[cbw]     : run clean, build then watch
-
-[d]oc     : generate documentation
+[c]lean   : remove all the generated files
+web       : Clean, build and start server for app "WEB" development
+api       : Clean, build and start server for app "API" development
+module    : Start cli tool to create new module
+unused    : Find useless packages

--- a/gulp-tasks/app.js
+++ b/gulp-tasks/app.js
@@ -1,0 +1,57 @@
+// Applications main tasks
+// - *:es6-clean => clean the generated files
+// - *:es6-build => transpile app files to lib
+// - *:es6-lint =>  run linter over the app sources
+// - *:es6-watch => watch source changes (and incudes changes) and run build
+
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')({camelize: true});
+var del = require('del');
+
+['web', 'api'].forEach(function(app) {
+  var appConfig = config.server.app[app];
+  var cfg = {
+    src : appConfig.src,
+    dist : appConfig.dist,
+    watch: [appConfig.src + '/**/*.js', config.server.includes.src],
+    tasks: {
+      clean: app + ':es6-clean',
+      build: app + ':es6-build',
+      lint: app + ':es6-lint',
+      watch: app + ':es6-lint',
+    }
+  };
+
+  gulp.task(cfg.tasks.build, function() {
+    return gulp.src(cfg.src + '/**/*.js')
+      .pipe($.sourcemaps.init())
+      .pipe($.babel(config.babel))
+      .pipe($.sourcemaps.write('.'))
+      .pipe(gulp.dest(cfg.dist));
+  });
+
+  gulp.task(cfg.tasks.lint, function() {
+    gulp.src(cfg.src + '/**/*.js')
+      .pipe($.eslint())
+      .pipe($.eslint.formatEach('compact', process.stderr))
+      .pipe($.eslint.failAfterError());
+  });
+
+  gulp.task(cfg.tasks.clean, function() {
+    del(cfg.dist + '/**/*');
+  });
+
+  gulp.task(app + ':es6-watch', function() {
+    return gulp.watch(cfg.watch, function(fileStatus) {
+      console.log('[ES6 watcher] ' + fileStatus.path + ' (' + fileStatus.type + ') ' + ' => transpile it into ' + cfg.dist);
+      return gulp.src(fileStatus.path, { base : cfg.src })
+        .pipe($.sourcemaps.init())
+        .pipe($.babel(config.babel))
+        .pipe($.sourcemaps.write('.'))
+        .pipe(gulp.dest(cfg.dist));
+    });
+  });
+});
+
+
+

--- a/gulp-tasks/dev/depcheck.js
+++ b/gulp-tasks/dev/depcheck.js
@@ -1,0 +1,26 @@
+// Chack unused packages.
+// As it grep, packages use with require(var) are not found...
+
+var gulp = require('gulp');
+var depcheck = require('depcheck');
+
+gulp.task('unusedPackages', function() {
+  var options = {
+    withoutDev: true,
+    ignoreDirs: ['src', 'locales', 'logs', 'public'],
+    ignoreMatches: ['gulp-*']
+  };
+
+  depcheck(config.root, options, function(unused) {
+    if(unused.dependencies.length > 0 || unused.devDependencies.length > 0) {
+      console.log('=> Package without usage');
+      if(unused.dependencies.length > 0) {
+        console.log(' - ' + unused.dependencies.join("\n - "));
+      }
+      if(unused.devDependencies.length > 0) {
+        console.log(' - (dev) ' + unused.devDependencies.join("\n - "));
+      }
+    }
+  });
+});
+

--- a/gulp-tasks/dev/module-generator.js
+++ b/gulp-tasks/dev/module-generator.js
@@ -1,0 +1,83 @@
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')({camelize: true});
+var inquirer = require('inquirer');
+var fs = require('fs');
+
+gulp.task('create-module', function (done) {
+  var srcPath = config.modules.templates;
+  var distPath = config.modules.src;
+  var moduleFiles = fs.readdirSync(srcPath).sort();
+
+  console.info('');
+  console.info('==============================');
+  console.info('  Generator for empty module');
+  console.info('==============================');
+  console.info('');
+
+  inquirer.prompt([
+    { type: 'input',
+      name: 'name',
+      message: 'Module name',
+      default: '',
+      validate: function(value) {
+        return value!=='';
+      }
+    },
+    { type: 'input',
+      name: 'collection',
+      message: 'Mongo Collection',
+      default: '',
+      validate: function(value) {
+        return value!=='';
+      }
+    },
+    { type: 'checkbox',
+      name: 'files',
+      message: 'What to generate ?',
+      choices: moduleFiles,
+      default: moduleFiles
+    },
+    { type: 'input',
+      name: 'destination',
+      message: 'Destination',
+      default: distPath
+    },
+    { type: 'confirm',
+      name: 'moveon',
+      message: 'Continue ?'
+    }
+  ],
+  function (answers) {
+
+    if (!answers.moveon) {
+      console.info('Module creation aborted');
+      return done();
+    }
+
+    var data = {
+      Lowername: answers.name.toLowerCase(),
+      Nicename: answers.name.charAt(0).toUpperCase() + answers.name.substr(1).toLowerCase(),
+      collection: answers.collection
+    };
+    var destinationFolder = answers.destination;
+
+    var sourcesFiles = answers.files;
+    sourcesFiles.forEach( function(file, index) {
+      sourcesFiles[index] = srcPath + file;
+    });
+
+    gulp.src(sourcesFiles)
+      .pipe($.data(data))
+      .pipe($.swig())
+      .pipe($.rename(function (path) {
+        path.dirname += '/' + data.Lowername;
+        path.extname = '.js';
+        console.info('Creating ' + path.basename + path.extname + ' in ' + destinationFolder + '/' + path.dirname);
+      }))
+      .pipe(gulp.dest(destinationFolder))
+      .on('end', function () {
+        console.info('Module ' + data.Nicename + ' created');
+        done();
+      });
+  });
+});

--- a/gulp-tasks/includes.js
+++ b/gulp-tasks/includes.js
@@ -1,0 +1,44 @@
+// Includes tasks
+// - includes:es6-clean => clean the generated files
+// - includes:es6-build => transpile inc. files to lib
+// - includes:es6-lint =>  run linter over the inc. sources
+// - includes:es6-watch => watch source changes and run build
+
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')({camelize: true});
+var del = require('del');
+
+var cfg = {
+  src: config.server.includes.src,
+  dist: config.server.includes.dist
+};
+
+gulp.task('includes:es6-build', function() {
+  return gulp.src(cfg.src + '/**/*.js')
+    .pipe($.sourcemaps.init())
+    .pipe($.babel(config.babel))
+    .pipe($.sourcemaps.write('.'))
+    .pipe(gulp.dest(cfg.dist));
+});
+
+gulp.task('includes:es6-lint', function() {
+  gulp.src(cfg.src + '/**/*.js')
+    .pipe($.eslint())
+    .pipe($.eslint.formatEach('compact', process.stderr))
+    .pipe($.eslint.failAfterError());
+});
+
+gulp.task('includes:es6-clean', function() {
+  del(cfg.dist + '/**/*');
+});
+
+gulp.task('includes:es6-watch', function() {
+  return gulp.watch(cfg.src + '/**/*.js', function(fileStatus) {
+    console.log('[ES6 watcher] ' + fileStatus.path + ' (' + fileStatus.type + ') ' + ' => transpile it into ' + cfg.dist);
+    return gulp.src(fileStatus.path, { base : cfg.src })
+      .pipe($.sourcemaps.init())
+      .pipe($.babel(config.babel))
+      .pipe($.sourcemaps.write('.'))
+      .pipe(gulp.dest(cfg.dist));
+  });
+});

--- a/gulp-tasks/serve.js
+++ b/gulp-tasks/serve.js
@@ -1,0 +1,34 @@
+// Run a nodemon for the apps, watching usefull lib files to restart
+// web:server
+// api:server
+
+var gulp = require('gulp');
+var $ = require('gulp-load-plugins')({camelize: true});
+
+function nodemon(env, cfg, key) {
+  $.nodemon({
+    script: cfg.dist + '/server.js',
+    ext: 'js html',
+    verbose: false,
+    env: {
+      NODE_ENV: env,
+      NODE_PATH: cfg.paths.join(':'),
+      APP_SLUG: key,
+    },
+    watch: [
+      cfg.dist + '/**/*.js',
+      config.server.includes.dist
+    ],
+    delay: 150
+  })
+  .on('restart', function (files) {
+    var filesStr = files ? 'Files changed: ' + files.join(', ') : '(manual request)';
+    console.log('[Server restarted]', filesStr);
+  });
+}
+
+['web', 'api'].forEach(function(app) {
+  gulp.task(app + ':server', function() {
+    nodemon(config.env, config.server.app[app], app);
+  });
+})

--- a/gulp-tasks/views.js
+++ b/gulp-tasks/views.js
@@ -1,0 +1,19 @@
+var gulp = require('gulp');
+var del = require('del');
+
+gulp.task('views:build', function() {
+    return gulp.src(config.views.src)
+      .pipe(gulp.dest(config.views.dist));
+});
+
+gulp.task('views:watch', function() {
+    return gulp.watch(config.views.src, function(fileStatus) {
+      console.log('[Views watcher] ' + fileStatus.type + ' ' + fileStatus.path);
+      return gulp.src(fileStatus.path)
+        .pipe(gulp.dest(config.views.dist));
+    });
+});
+
+gulp.task('views:clean', function(cb) {
+  del(config.views.dist + '/**/*', cb);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,19 +1,32 @@
-'use strict';
-
 var gulp = require('gulp');
-var $ = require('gulp-load-plugins')({camelize: true});
-var del = require('del');
 var runSequence = require('run-sequence');
-var options = process.argv.slice(2);
-var depcheck = require('depcheck');
 var path = require('path');
-var inquirer = require('inquirer');
-var fs = require('fs');
+var requireDir = require('require-dir');
 
-var config = {
-  es6: {
-    src: './src',
-    dist: './lib'
+global.config = {
+  root: path.resolve('.'),
+  env: 'development',
+  server: {
+    app: {
+      web: {
+        src: __dirname + '/src/app/web',
+        dist: __dirname + '/lib/app/web',
+        paths: ['./lib/app/web', './lib/includes'],
+      },
+      api: {
+        src: __dirname + '/src/app/api',
+        dist: __dirname + '/lib/app/api',
+        paths: ['./lib/app/api', './lib/includes'],
+      },
+    },
+    includes: {
+      src: __dirname + '/src/includes',
+      dist: __dirname + '/lib/includes',
+    },
+  },
+  modules: {
+    templates: __dirname + '/dev/modules/templates/',
+    src: __dirname + '/src/includes/modules/',
   },
   views: {
     src: './src/**/*.html',
@@ -27,243 +40,39 @@ var config = {
   }
 };
 
+requireDir('./gulp-tasks', { recurse: true });
 
 gulp.task('clean', function() {
   runSequence(
-    ['es6:clean', 'views:clean']
+    ['web:es6-clean', 'api:es6-clean', 'includes:es6-clean', 'views:clean']
   );
 });
 
 gulp.task('build', function() {
   runSequence(
-    ['es6', 'views'],
-    ['unusedPackages']
+    ['clean'],
+    ['views:build', 'includes:es6-build'],
+    ['web:es6-build', 'api:es6-build']
   );
 });
 
-gulp.task('watch', function() {
+gulp.task('web:dev', function() {
   runSequence(
-    ['server'],
-    ['es6:watch', 'views:watch']
+    ['web:es6-clean', 'web:es6-lint'],
+    ['includes:es6-build'],
+    ['web:es6-build', 'views:build'],
+    ['includes:es6-watch', 'web:es6-watch', 'views:watch'],
+    ['web:server']
   );
 });
 
-gulp.task('watch:api', function() {
+gulp.task('api:dev', function() {
   runSequence(
-    ['server:api']
+    ['api:es6-clean', 'api:es6-lint'],
+    ['includes:es6-build'],
+    ['api:es6-build'],
+    ['includes:es6-watch', 'api:es6-watch'],
+    ['api:server']
   );
 });
 
-gulp.task('views', function() {
-    return gulp.src(config.views.src)
-      .pipe(gulp.dest(config.views.dist));
-});
-
-gulp.task('views:watch', function() {
-    return gulp.watch(config.views.src, function(fileStatus) {
-      console.log('[Views watcher] ' + fileStatus.type + ' ' + fileStatus.path);
-      return gulp.src(fileStatus.path)
-        .pipe(gulp.dest(config.views.dist));
-    });
-});
-
-gulp.task('views:clean', function(cb) {
-  del(config.views.dist + '/**/*', cb);
-});
-
-gulp.task('es6', ['es6:lint'], function() {
-    return gulp.src(config.es6.src + '/**/*.js')
-      .pipe($.sourcemaps.init())
-      .pipe($.babel(config.babel))
-      .pipe($.sourcemaps.write('.'))
-      .pipe(gulp.dest(config.es6.dist));
-});
-
-gulp.task('es6:watch', function() {
-    return gulp.watch(config.es6.src + '/**/*.js', function(fileStatus) {
-      var path = fileStatus.path.replace(__dirname, '');
-      console.log('[ES6 watcher] ' + path + ' (' + fileStatus.type + ') ' +
-        ' => transpile it into ' + config.es6.dist);
-
-      return gulp.src(fileStatus.path, { base : config.es6.src })
-        .pipe($.sourcemaps.init())
-        .pipe($.babel(config.babel))
-        .pipe($.sourcemaps.write('.')) // @tofix
-        .pipe(gulp.dest(config.es6.dist));
-    });
-});
-
-gulp.task('es6:clean', function(cb) {
-  del(config.es6.dist + '/**/*', cb);
-});
-
-gulp.task('es6:lint', function() {
-  gulp.src(config.es6.src + '/**/*.js')
-    .pipe($.eslint())
-    .pipe($.eslint.formatEach('compact', process.stderr))
-    .pipe($.eslint.failAfterError());
-});
-
-gulp.task('unusedPackages', function() {
-  var options = {
-    withoutDev: true,
-    ignoreDirs: ['src', 'locales', 'logs', 'public'],
-    ignoreMatches: ['gulp-*']
-  };
-
-  var root = path.resolve('.');
-  depcheck(root, options, function(unused) {
-    if(unused.dependencies.length > 0 || unused.devDependencies.length > 0) {
-      console.log('=> Some packages are useless and should be removed');
-      if(unused.dependencies.length > 0) {
-        console.log('- ' + unused.dependencies.join("\n - "));
-      }
-      if(unused.devDependencies.length > 0) {
-        console.log('- (dev) ' + unused.devDependencies.join("\n - "));
-      }
-    }
-  });
-});
-
-
-// =============================================================================
-// Serve =======================================================================
-// =============================================================================
-
-gulp.task('server', function() {
-  $.nodemon({
-    script: 'lib/app/web/server.js',
-    ext: 'js html',
-    verbose: false,
-    env: {
-      NODE_ENV: options.env ? options.env : 'development',
-      NODE_PATH: './lib/app/web:./lib/includes',
-      APP_SLUG: 'web',
-    },
-    watch: [
-      'lib/**/*.js'
-    ],
-    ignore: [
-      'logs/**/*',
-      'node_modules/**/*',
-      'public/**/*',
-      'src/**/*'
-    ],
-    delay: 150
-  })
-  .on('restart', function (files) {
-    var filesStr = files ? 'Files changed: ' + files.join(', ') : '(manual request)';
-    console.log('[Server restarted]', filesStr);
-  });
-});
-
-gulp.task('server:api', function() {
-  $.nodemon({
-    script: 'lib/app/api/server.js',
-    ext: 'js html',
-    verbose: false,
-    env: {
-      NODE_ENV: options.env ? options.env : 'development',
-      NODE_PATH: './lib/app/api:./lib/includes',
-      APP_SLUG: 'api',
-    },
-    watch: [
-      'lib/**/*.js'
-    ],
-    ignore: [
-      'logs/**/*',
-      'node_modules/**/*',
-      'public/**/*',
-      'src/**/*'
-    ],
-    delay: 150
-  })
-  .on('restart', function (files) {
-    var filesStr = files ? 'Files changed: ' + files.join(', ') : '(manual request)';
-    console.log('[Server restarted]', filesStr);
-  });
-});
-
-
-// =============================================================================
-// Dev tool ====================================================================
-// =============================================================================
-
-gulp.task('module', function (done) {
-  var srcPath = __dirname + '/dev/modules/templates/';
-  var distPath = path.resolve(__dirname + '/src/includes/modules/');
-  let moduleFiles = fs.readdirSync(srcPath).sort();
-
-  console.info('');
-  console.info('==============================');
-  console.info('  Generator for empty module');
-  console.info('==============================');
-  console.info('');
-
-  inquirer.prompt([
-    { type: 'input',
-      name: 'name',
-      message: 'Module name',
-      default: '',
-      validate: function(value) {
-        return value!=='';
-      }
-    },
-    { type: 'input',
-      name: 'collection',
-      message: 'Mongo Collection',
-      default: '',
-      validate: function(value) {
-        return value!=='';
-      }
-    },
-    { type: 'checkbox',
-      name: 'files',
-      message: 'What to generate ?',
-      choices: moduleFiles,
-      default: moduleFiles
-    },
-    { type: 'input',
-      name: 'destination',
-      message: 'Destination',
-      default: distPath
-    },
-    { type: 'confirm',
-      name: 'moveon',
-      message: 'Continue ?'
-    }
-  ],
-  function (answers) {
-
-    if (!answers.moveon) {
-      console.info('Module creation aborted');
-      return done();
-    }
-
-    var data = {
-      Lowername: answers.name.toLowerCase(),
-      Nicename: answers.name.charAt(0).toUpperCase() + answers.name.substr(1).toLowerCase(),
-      collection: answers.collection
-    };
-    var destinationFolder = answers.destination;
-
-    var sourcesFiles = answers.files;
-    sourcesFiles.forEach( function(file, index) {
-      sourcesFiles[index] = srcPath + file;
-    });
-
-    gulp.src(sourcesFiles)
-      .pipe($.data(data))
-      .pipe($.swig())
-      .pipe($.rename(function (path) {
-        path.dirname += '/' + data.Lowername;
-        path.extname = '.js';
-        console.info('Creating ' + path.basename + path.extname + ' in ' + destinationFolder + '/' + path.dirname);
-      }))
-      .pipe(gulp.dest(destinationFolder))
-      .on('end', function () {
-        console.info('Module ' + data.Nicename + ' created');
-        done();
-      });
-  });
-});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "passthrough-counter": "^1.0.0",
     "piggy-htmldoc": "^0.0.2",
     "piggy-module": "^0.0.12",
+    "require-dir": "^0.3.0",
     "springbokjs-errors": "^2.1.0",
     "winston": "^1.0.0"
   },


### PR DESCRIPTION
- move all ubtasks in gulp-tasks
- split apps and includes as they have no dependancy
- split api/web app
- more config
- most used in gulpfile
- Makefile rewritten to match the new tasks

_Will be a clean base to start frontend stuff..._
